### PR TITLE
Change KVal::new to accept reference instead of raw pointer

### DIFF
--- a/src/kbindings.rs
+++ b/src/kbindings.rs
@@ -123,9 +123,12 @@ pub enum KVal<'a> {
 }
 
 impl<'a> KVal<'a> {
-    pub fn new(k: *const K) -> KVal<'a> {
+    pub unsafe fn from_raw(k: *const K) -> KVal<'a> {
+        Self::new(&*k)
+    }
+
+    pub fn new(k: &'a K) -> KVal<'a> {
         unsafe {
-            let k = &*k;
             match k.t {
                 -1 => KVal::Bool(KData::atom(k)),
                 -2 => KVal::Guid(KData::guid_atom(k)), 
@@ -184,7 +187,7 @@ impl<'a> KVal<'a> {
                 17 => KVal::Minute( KData::list(k)),
                 18 => KVal::Second( KData::list(k)),
                 19 => KVal::Time( KData::list(k)),
-                98 => KVal::Table(  Box::new(KVal::new(*k.cast::<*const K>()))),
+                98 => KVal::Table( Box::new(KVal::new(k))),
                 99 => {
                     let slice = k.fetch_slice::<&K>();
                     KVal::Dict(   Box::new(KVal::new(slice[0])),


### PR DESCRIPTION
Addresses the following clippy error:

```
error: this public function dereferences a raw pointer but is not marked `unsafe`
   --> src/kbindings.rs:128:23
    |
128 |             let k = &*k;
    |                       ^
    |
    = note: `#[deny(clippy::not_unsafe_ptr_arg_deref)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref
```

This is a breaking change, as it alters the method signature. An alternative fix would be to mark the entire function as unsafe, but that would be less desirable for the API.

If you are unable to merge this as-is, because it breaks too much of your application, we could introduce the safe version as a new method and preserve the original method, renamed to something like `new_from_raw`.